### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/elsabot/skills/rule_response.py
+++ b/elsabot/skills/rule_response.py
@@ -8,7 +8,7 @@ import ipdb
 from nlptools.text.docsim import WMDSim
 from nlptools.text.embedding import Embedding
 from nlptools.text.tokenizer import format_sentence
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 from .skill_base import SkillBase
 
 

--- a/elsabot/skills/skill_base.py
+++ b/elsabot/skills/skill_base.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import numpy, re
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz, process
 
 """
     Author: Pengjia Zhu (zhupengjia@gmail.com)
@@ -67,11 +67,10 @@ class SkillBase:
         match and replace entity name in text
         """
         upper = regroup.group(1).upper()
-        scores = [fuzz.partial_ratio(upper, e) for e in all_entities]
-        max_id = numpy.argmax(scores)
-        max_score = scores[max_id]
-        if max_score > 80:
-            return "{" + all_entities[max_id] +"}"
+        match process.extractOne(upper, all_entities,
+            processor=None, scorer=fuzz.partial_ratio, score_cutoff=80)
+        if match:
+            return "{" + match[0] +"}"
         else:
             return regroup.group(1)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,5 @@ nltk
 xlrd
 slixmpp
 SymSpell
-fuzzywuzzy
-python-Levenshtein
+rapidfuzz
 symspellpy


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy